### PR TITLE
feat: Add firmware summary table to AI release notes

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -180,3 +180,40 @@ jobs:
           name: "logger-test-results"
           path: "output/test-results/"
           retention-days: 7
+
+  firmware-summary-test:
+    name: "Firmware Summary Unit Test"
+    runs-on: "ubuntu-latest"
+    if: >-
+      github.event_name == 'push' || github.event_name == 'pull_request'
+    needs: []
+    steps:
+      - name: "Checkout code"
+        uses: actions/checkout@v4
+
+      - name: "Install dependencies"
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y zsh exiftool jq
+
+      - name: "Make test scripts executable"
+        run: |
+          chmod +x scripts/testing/*.zsh
+
+      - name: "Setup output directories"
+        run: |
+          mkdir -p output/test-results
+          mkdir -p output/test-temp
+
+      - name: "Run firmware summary unit test"
+        run: |
+          echo "🧪 Running firmware summary unit test..."
+          ./scripts/testing/run-tests.zsh --firmware-summary
+
+      - name: "Upload firmware summary test results"
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: "firmware-summary-test-results"
+          path: "output/test-results/"
+          retention-days: 7

--- a/AI_INSTRUCTIONS.md
+++ b/AI_INSTRUCTIONS.md
@@ -130,6 +130,73 @@ This document establishes the foundational architectural decisions and design pa
 - Whenever a new GitHub issue is created, immediately run `scripts/maintenance/generate-issues-markdown.zsh` to update the local Markdown issue list.
 - After generating the issue list, read the output file (`output/github_issues.md`) to ensure you are memorizing and referencing the latest issues in all future work and communication.
 
+## GitHub Command Intermediate Documents (MANDATORY)
+**CRITICAL: For any GitHub issue or PR creation commands with complex formatting or long content, ALWAYS create an intermediate document first to avoid formatting issues and process hangs.**
+
+**Rationale**: Complex GitHub CLI commands with long bodies, multiple parameters, or special characters can cause formatting issues, syntax errors, or process hangs. Creating intermediate documents ensures reliable command execution and proper formatting.
+
+**Requirements**:
+- **Create intermediate document** for any GitHub command with:
+  - Long body text (more than 200 characters)
+  - Multiple parameters or complex formatting
+  - Special characters or markdown formatting
+  - Multiple labels or assignees
+  - Complex issue/PR descriptions
+
+- **Document location**: `output/` directory
+- **Naming convention**: `output/<command_type>_<timestamp>.md` (e.g., `output/pr_body_20250629_153000.md`)
+- **Content format**: Clean markdown with proper formatting
+
+**Implementation Process**:
+1. **Create intermediate document** in `output/` directory
+2. **Write content** with proper markdown formatting
+3. **Read document content** into variable or use file reference
+4. **Execute GitHub command** using the document content
+5. **Clean up** intermediate document after successful execution
+
+**Examples**:
+```zsh
+# Create intermediate document for complex PR
+cat > output/pr_body_$(date +%Y%m%d_%H%M%S).md << 'EOF'
+## Summary
+Complex PR description with multiple sections...
+
+## Requirements
+- Feature A
+- Feature B
+
+## Motivation
+Detailed explanation...
+
+## Acceptance Criteria
+- [ ] Criterion 1
+- [ ] Criterion 2
+EOF
+
+# Use document in GitHub command
+gh pr create --title "title" --body-file output/pr_body_*.md --assignee fxstein --label enhancement
+```
+
+**Benefits**:
+- ✅ **Reliable execution** - Avoids command line length limits
+- ✅ **Proper formatting** - Maintains markdown structure
+- ✅ **Error prevention** - Reduces syntax and formatting issues
+- ✅ **Easy editing** - Can review and modify content before execution
+- ✅ **Cleanup** - Intermediate files are in `output/` directory (gitignored)
+
+**Enforcement**:
+- **MANDATORY** for all complex GitHub commands
+- **Failure to follow** will result in immediate correction
+- **Always use** for issue/PR creation with detailed content
+- **Clean up** intermediate files after successful execution
+
+**Common Use Cases**:
+- Creating detailed GitHub issues with multiple sections
+- Creating pull requests with comprehensive descriptions
+- Adding complex labels and assignees
+- Including formatted markdown content
+- Multi-line descriptions or requirements
+
 ## Pull Request Issue Closure Rules (MANDATORY)
 - **NEVER assume whether a PR closes an issue** - always ask the user if the PR closes the entire issue or is just a partial implementation
 - **Use "Related to #X" instead of "Closes #X"** unless explicitly told by the user that the PR closes the issue

--- a/docs/release/RELEASE_SUMMARY_INSTRUCTIONS.md
+++ b/docs/release/RELEASE_SUMMARY_INSTRUCTIONS.md
@@ -15,20 +15,46 @@ This document defines the required content and formatting for the major changes 
 - Keep process improvements as a minor part of the summary
 
 ## Required Content Sections
-- **New GoPro Models**: List any new GoPro camera models added since the base release
-- **Official Firmware**: List new official firmware releases added, grouped by model
-- **Labs Firmware**: List new GoPro Labs firmware releases added, grouped by model
-- **Core Functionality**: SD card management, firmware updates, tool improvements
-- **Infrastructure**: CI/CD and process improvements (minor section)
+
+### 1. Firmware Summary (MANDATORY - Top of Document)
+- **MUST** include the current firmware support status at the very top of the release notes
+- Run `./scripts/release/generate-firmware-summary.zsh` to generate the firmware table
+- This provides users with immediate visibility into supported models and latest firmware versions
+- Place this section before any other content
+
+### 2. New GoPro Models
+- List any new GoPro camera models added since the base release
+
+### 3. Official Firmware
+- List new official firmware releases added, grouped by model
+
+### 4. Labs Firmware
+- List new GoPro Labs firmware releases added, grouped by model
+
+### 5. Core Functionality
+- SD card management, firmware updates, tool improvements
+
+### 6. Infrastructure
+- CI/CD and process improvements (minor section)
 
 ## Formatting Requirements
 - **DO NOT** include a main header (e.g., "# Major Changes Since vXX.XX.XX") – the main process creates this
-- Start directly with section headers (e.g., `## New GoPro Models`)
+- Start directly with the firmware summary table
 - Use bullet points for all lists
 - Group firmware by model and type (Official vs Labs)
 
 ## Example Structure
 ```markdown
+## Supported GoPro Models
+
+The following GoPro camera models are currently supported by GoProX:
+
+| Model | Latest Official | Latest Labs |
+|-------|-----------------|-------------|
+| GoPro Max | H19.03.02.02.00 | H19.03.02.02.70 |
+| HERO10 Black | H21.01.01.62.00 | H21.01.01.62.70 |
+| HERO11 Black | H22.01.02.32.00 | H22.01.02.32.70 |
+
 ## New GoPro Models
 - HERO12 Black
 

--- a/scripts/release/generate-firmware-summary.zsh
+++ b/scripts/release/generate-firmware-summary.zsh
@@ -1,0 +1,95 @@
+#!/bin/zsh
+
+# Generate firmware summary for release notes
+# This script creates a comprehensive list of supported GoPro models and their latest firmware versions
+
+SCRIPT_DIR="${0:A:h}"
+source "$SCRIPT_DIR/../core/logger.zsh"
+init_logger "generate-firmware-summary"
+
+log_info "Generating firmware summary for release notes"
+
+# Function to get latest firmware version for a model
+get_latest_firmware() {
+    local model_dir="$1"
+    local latest_version=""
+    
+    if [[ ! -d "$model_dir" ]]; then
+        return 1
+    fi
+    
+    for version_dir in "$model_dir"/*/; do
+        if [[ -d "$version_dir" ]]; then
+            local version=$(basename "$version_dir")
+            if [[ "$version" == ".keep" ]] || [[ "$version" == "README.txt" ]]; then
+                continue
+            fi
+            if [[ "$version" > "$latest_version" ]]; then
+                latest_version="$version"
+            fi
+        fi
+    done
+    
+    echo "$latest_version"
+}
+
+# Initialize associative arrays
+typeset -A official_firmware
+typeset -A labs_firmware
+typeset -a all_models
+
+# Process official firmware
+for model_dir in firmware/official/*/; do
+    if [[ -d "$model_dir" ]]; then
+        model_name=$(basename "$model_dir")
+        model_name=${model_name//\"/}  # Remove any embedded quotes
+        if [[ "$model_name" != ".keep" ]] && [[ "$model_name" != "README.txt" ]]; then
+            latest_version=$(get_latest_firmware "$model_dir")
+            official_firmware[$model_name]="$latest_version"
+            all_models+=("$model_name")
+        fi
+    fi
+done
+
+# Process labs firmware
+for model_dir in firmware/labs/*/; do
+    if [[ -d "$model_dir" ]]; then
+        model_name=$(basename "$model_dir")
+        model_name=${model_name//\"/}  # Remove any embedded quotes
+        if [[ "$model_name" != ".keep" ]] && [[ "$model_name" != "README.txt" ]]; then
+            latest_version=$(get_latest_firmware "$model_dir")
+            labs_firmware[$model_name]="$latest_version"
+            # Only add to all_models if not already present
+            if [[ ! " ${all_models[@]} " =~ " ${model_name} " ]]; then
+                all_models+=("$model_name")
+            fi
+        fi
+    fi
+done
+
+# Sort models for output
+sorted_models=()
+while IFS= read -r model; do
+    sorted_models+=("$model")
+done < <(printf '%s\n' "${all_models[@]}" | sort)
+
+# Generate the summary
+log_info "Generating firmware summary markdown"
+
+cat << 'EOF'
+## Supported GoPro Models
+
+The following GoPro camera models are currently supported by GoProX:
+
+EOF
+
+# Single table with latest official and labs firmware
+echo "| Model | Latest Official | Latest Labs |"
+echo "|-------|-----------------|-------------|"
+for model in "${sorted_models[@]}"; do
+    official_ver="${official_firmware[$model]:-N/A}"
+    labs_ver="${labs_firmware[$model]:-N/A}"
+    echo "| $model | $official_ver | $labs_ver |"
+done
+
+log_info "Firmware summary generation completed" 

--- a/scripts/release/generate-firmware-summary.zsh
+++ b/scripts/release/generate-firmware-summary.zsh
@@ -73,6 +73,30 @@ while IFS= read -r model; do
     sorted_models+=("$model")
 done < <(printf '%s\n' "${all_models[@]}" | sort)
 
+# Calculate column widths
+model_width=5  # "Model" header length
+official_width=15  # "Latest Official" header length
+labs_width=11  # "Latest Labs" header length
+
+for model in "${sorted_models[@]}"; do
+    model_len=${#model}
+    if [[ $model_len -gt $model_width ]]; then
+        model_width=$model_len
+    fi
+    
+    official_ver="${official_firmware[$model]:-N/A}"
+    official_len=${#official_ver}
+    if [[ $official_len -gt $official_width ]]; then
+        official_width=$official_len
+    fi
+    
+    labs_ver="${labs_firmware[$model]:-N/A}"
+    labs_len=${#labs_ver}
+    if [[ $labs_len -gt $labs_width ]]; then
+        labs_width=$labs_len
+    fi
+done
+
 # Generate the summary
 log_info "Generating firmware summary markdown"
 
@@ -83,13 +107,14 @@ The following GoPro camera models are currently supported by GoProX:
 
 EOF
 
-# Single table with latest official and labs firmware
-echo "| Model | Latest Official | Latest Labs |"
-echo "|-------|-----------------|-------------|"
+# Generate properly formatted table
+printf "| %-${model_width}s | %-${official_width}s | %-${labs_width}s |\n" "Model" "Latest Official" "Latest Labs"
+printf "|%s|%s|%s|\n" "$(printf '%*s' $((model_width + 2)) '' | tr ' ' '-')" "$(printf '%*s' $((official_width + 2)) '' | tr ' ' '-')" "$(printf '%*s' $((labs_width + 2)) '' | tr ' ' '-')"
+
 for model in "${sorted_models[@]}"; do
     official_ver="${official_firmware[$model]:-N/A}"
     labs_ver="${labs_firmware[$model]:-N/A}"
-    echo "| $model | $official_ver | $labs_ver |"
+    printf "| %-${model_width}s | %-${official_width}s | %-${labs_width}s |\n" "$model" "$official_ver" "$labs_ver"
 done
 
 log_info "Firmware summary generation completed" 

--- a/scripts/release/generate-firmware-summary.zsh
+++ b/scripts/release/generate-firmware-summary.zsh
@@ -67,11 +67,34 @@ for model_dir in firmware/labs/*/; do
     fi
 done
 
-# Sort models for output
+# Sort models in custom order
 sorted_models=()
-while IFS= read -r model; do
-    sorted_models+=("$model")
-done < <(printf '%s\n' "${all_models[@]}" | sort)
+custom_order=(
+    "HERO13 Black"
+    "HERO (2024)"
+    "HERO12 Black"
+    "HERO11 Black"
+    "HERO11 Black Mini"
+    "HERO10 Black"
+    "HERO9 Black"
+    "HERO8 Black"
+    "GoPro Max"
+    "The Remote"
+)
+
+# Add models in custom order if they exist
+for model in "${custom_order[@]}"; do
+    if [[ " ${all_models[@]} " =~ " ${model} " ]]; then
+        sorted_models+=("$model")
+    fi
+done
+
+# Add any remaining models that weren't in the custom order (alphabetically)
+for model in "${all_models[@]}"; do
+    if [[ ! " ${sorted_models[@]} " =~ " ${model} " ]]; then
+        sorted_models+=("$model")
+    fi
+done
 
 # Calculate column widths
 model_width=5  # "Model" header length

--- a/scripts/release/generate-firmware-summary.zsh
+++ b/scripts/release/generate-firmware-summary.zsh
@@ -108,14 +108,22 @@ known_models=()
 unknown_models=()
 
 for model in "${all_models[@]}"; do
-    if [[ " ${custom_order[@]} " =~ " ${model} " ]]; then
+    local found=false
+    for known_model in "${custom_order[@]}"; do
+        if [[ "$model" == "$known_model" ]]; then
+            found=true
+            break
+        fi
+    done
+    
+    if [[ "$found" == true ]]; then
         known_models+=("$model")
     else
         unknown_models+=("$model")
     fi
 done
 
-# Sort unknown models by firmware version (newest first)
+# Sort unknown models by firmware version (newest first) and add at the top
 if [[ ${#unknown_models[@]} -gt 0 ]]; then
     # Create temporary array with model and version pairs
     temp_models=()
@@ -141,11 +149,14 @@ if [[ ${#unknown_models[@]} -gt 0 ]]; then
     sorted_models+=("${sorted_unknown[@]}")
 fi
 
-# Add known models in custom order
+# Add known models in the exact custom order specified
 for model in "${custom_order[@]}"; do
-    if [[ " ${known_models[@]} " =~ " ${model} " ]]; then
-        sorted_models+=("$model")
-    fi
+    for known in "${known_models[@]}"; do
+        if [[ "$model" == "$known" ]]; then
+            sorted_models+=("$model")
+            break
+        fi
+    done
 done
 
 # Calculate column widths

--- a/scripts/testing/run-tests.zsh
+++ b/scripts/testing/run-tests.zsh
@@ -36,6 +36,7 @@ RUN_MEDIA_TESTS=false
 RUN_ERROR_TESTS=false
 RUN_WORKFLOW_TESTS=false
 RUN_LOGGER_TESTS=false
+RUN_FIRMWARE_SUMMARY_TESTS=false
 VERBOSE=false
 QUIET=false
 DEBUG=false
@@ -84,6 +85,10 @@ function parse_options() {
                 RUN_LOGGER_TESTS=true
                 shift
                 ;;
+            --firmware-summary)
+                RUN_FIRMWARE_SUMMARY_TESTS=true
+                shift
+                ;;
             --verbose|-v)
                 VERBOSE=true
                 shift
@@ -113,7 +118,8 @@ function parse_options() {
           "$RUN_PARAM_TESTS" == false && "$RUN_STORAGE_TESTS" == false && \
           "$RUN_INTEGRATION_TESTS" == false && "$RUN_ENHANCED_TESTS" == false && \
           "$RUN_MEDIA_TESTS" == false && "$RUN_ERROR_TESTS" == false && \
-          "$RUN_WORKFLOW_TESTS" == false && "$RUN_LOGGER_TESTS" == false ]]; then
+          "$RUN_WORKFLOW_TESTS" == false && "$RUN_LOGGER_TESTS" == false && \
+          "$RUN_FIRMWARE_SUMMARY_TESTS" == false ]]; then
         RUN_ALL_TESTS=true
     fi
 
@@ -129,6 +135,7 @@ function parse_options() {
         echo "  RUN_ERROR_TESTS=$RUN_ERROR_TESTS"
         echo "  RUN_WORKFLOW_TESTS=$RUN_WORKFLOW_TESTS"
         echo "  RUN_LOGGER_TESTS=$RUN_LOGGER_TESTS"
+        echo "  RUN_FIRMWARE_SUMMARY_TESTS=$RUN_FIRMWARE_SUMMARY_TESTS"
     fi
 }
 
@@ -149,6 +156,7 @@ function show_help() {
     echo "  --error            Run error handling tests only"
     echo "  --workflow         Run workflow tests only"
     echo "  --logger           Run logger tests only"
+    echo "  --firmware-summary Run firmware summary tests only"
     echo "  --verbose, -v      Enable verbose output"
     echo "  --quiet, -q        Suppress output except for failures"
     echo "  --debug            Enable debug output"
@@ -247,8 +255,12 @@ function run_selected_tests() {
         test_suite "Integration Workflow Tests" test_integration_workflows_suite
     fi
     
-    if [[ "$RUN_LOGGER_TESTS" == true ]]; then
+    if [[ "$RUN_ALL_TESTS" == true || "$RUN_LOGGER_TESTS" == true ]]; then
         test_suite "Logger Tests" test_logger_suite
+    fi
+    
+    if [[ "$RUN_ALL_TESTS" == true || "$RUN_FIRMWARE_SUMMARY_TESTS" == true ]]; then
+        test_suite "Firmware Summary Tests" test_firmware_summary_suite
     fi
     
     if [[ "$DEBUG" == true ]]; then


### PR DESCRIPTION
## Summary

This PR enhances the GoProX AI release summary process by adding a comprehensive firmware summary table that shows supported GoPro models and their latest official and labs firmware versions.

## Requirements

- Add firmware summary table to AI release notes
- Table should appear at the very top of release notes (before main header)
- Include all supported GoPro models with latest firmware versions
- Sort models in custom order: HERO13 → HERO (2024) → HERO12 → HERO11 → HERO11 Mini → HERO10 → HERO9 → HERO8 → GoPro Max → The Remote
- Handle models with spaces in names correctly
- Use proper markdown table formatting with aligned columns

## Motivation

Users need immediate visibility into which GoPro models are supported by GoProX and what the latest firmware versions are. This information should be prominently displayed at the top of all release notes.

## Acceptance Criteria

- [x] Firmware summary script generates clean, properly formatted markdown table
- [x] Table includes all supported models from firmware directories
- [x] Models are sorted in the specified custom order
- [x] Table handles model names with spaces correctly (e.g., 'HERO (2024)', 'HERO11 Black Mini')
- [x] Unknown models are sorted by firmware version at the top
- [x] AI release instructions updated to mandate firmware table inclusion
- [x] Table renders cleanly in markdown with proper column alignment
- [x] Script is future-proof for new models

## Reference

- Issue #20: AI release summary firmware info enhancement
- AI_INSTRUCTIONS.md updated with new requirements
- RELEASE_SUMMARY_INSTRUCTIONS.md updated with firmware table mandate 