### PR TITLE
fix: resolve read-only variable error in release script

### DIFF
--- a/scripts/release/gitflow-release.zsh
+++ b/scripts/release/gitflow-release.zsh
@@ -515,7 +515,7 @@ monitor_github_actions() {
                     echo "❌ Some workflows failed! Manual intervention required."
                     echo ""
                     echo "📋 Failed Workflow Details:"
-                    echo "$relevant_workflows" | while IFS='|' read -r run_number workflow_name status conclusion; do
+                    echo "$relevant_workflows" | while IFS='|' read -r run_number workflow_name wf_status conclusion; do
                         [[ -z "$run_number" ]] && continue
                         if [[ "$conclusion" != "success" ]]; then
                             echo "   Workflow: $workflow_name (#$run_number)"


### PR DESCRIPTION
## Summary
Fix for read-only variable error in the release script that was preventing proper GitHub Actions workflow monitoring.

## Problem
The release script was failing with a "read-only variable: status" error when monitoring GitHub Actions workflows. This occurred because `status` is a reserved variable in zsh and cannot be used as a local variable in while loops.

## Solution
- Changed the variable name from `status` to `wf_status` in the `monitor_github_actions` function
- This avoids the zsh reserved variable conflict while maintaining all functionality
- The fix is minimal and targeted, only affecting the problematic variable name

## Changes Made
- **File**: `scripts/release/gitflow-release.zsh`
- **Function**: `monitor_github_actions`
- **Change**: Renamed `status` variable to `wf_status` in while loop

## Testing
- Verified the release script help command works without errors
- The fix maintains all existing functionality
- No other parts of the release process are affected

## Impact
- Fixes the release script so it can properly monitor GitHub Actions workflows
- Enables successful release operations that were previously failing
- No breaking changes or functional modifications

## Related Issues
- Addresses release script errors mentioned in #72
- Enables proper CI/CD integration for release processes 