### PR TITLE
fix: simplify logger, fix prompts, and restore clean interactive release (refs #67 #71 #72)

### DIFF
--- a/scripts/core/logger.zsh
+++ b/scripts/core/logger.zsh
@@ -4,26 +4,74 @@
 # All output goes to stderr to avoid interfering with interactive prompts
 #
 
-# Simple logging functions - no fallbacks, no complexity
+# Function to get current branch with hash display
+get_branch_display() {
+    local current_branch=$(git branch --show-current 2>/dev/null || echo "unknown")
+    local branch_hash=$(echo "$current_branch" | sha1sum | cut -c1-8 2>/dev/null || echo "unknown")
+    
+    # For short branches (≤15 chars), show full name
+    # For longer branches, show type prefix + hash
+    if [[ ${#current_branch} -le 15 ]]; then
+        echo "$current_branch"
+    else
+        # Extract branch type prefix
+        local branch_type=""
+        if [[ "$current_branch" =~ ^fix/ ]]; then
+            branch_type="fix"
+        elif [[ "$current_branch" =~ ^feat/ ]]; then
+            branch_type="feat"
+        elif [[ "$current_branch" =~ ^feature/ ]]; then
+            branch_type="feat"
+        elif [[ "$current_branch" =~ ^release/ ]]; then
+            branch_type="rel"
+        elif [[ "$current_branch" =~ ^hotfix/ ]]; then
+            branch_type="hot"
+        elif [[ "$current_branch" == "develop" ]]; then
+            branch_type="dev"
+        elif [[ "$current_branch" == "main" ]]; then
+            branch_type="main"
+        else
+            branch_type="other"
+        fi
+        echo "${branch_type}/${branch_hash}"
+    fi
+}
+
+# Function to get formatted timestamp
+get_timestamp() {
+    date '+%Y-%m-%d %H:%M:%S'
+}
+
+# Simple logging functions with formatting
 log_info() {
-    echo "[INFO] $*" >&2
+    local ts=$(get_timestamp)
+    local branch=$(get_branch_display)
+    echo "[$ts] [$branch] [INFO] $*" >&2
 }
 
 log_success() {
-    echo "[SUCCESS] $*" >&2
+    local ts=$(get_timestamp)
+    local branch=$(get_branch_display)
+    echo "[$ts] [$branch] [SUCCESS] $*" >&2
 }
 
 log_warning() {
-    echo "[WARNING] $*" >&2
+    local ts=$(get_timestamp)
+    local branch=$(get_branch_display)
+    echo "[$ts] [$branch] [WARNING] $*" >&2
 }
 
 log_error() {
-    echo "[ERROR] $*" >&2
+    local ts=$(get_timestamp)
+    local branch=$(get_branch_display)
+    echo "[$ts] [$branch] [ERROR] $*" >&2
 }
 
 log_debug() {
     if [[ "${DEBUG:-}" == "1" || "${DEBUG:-}" == "true" ]]; then
-        echo "[DEBUG] $*" >&2
+        local ts=$(get_timestamp)
+        local branch=$(get_branch_display)
+        echo "[$ts] [$branch] [DEBUG] $*" >&2
     fi
 }
 

--- a/scripts/core/logger.zsh
+++ b/scripts/core/logger.zsh
@@ -1,93 +1,31 @@
 #!/bin/zsh
-# logger.zsh: Centralized logging module for GoProX scripts
 #
-# Usage:
-#   export LOGFILE=relative/or/absolute/path/to/logfile.log  # Optional
-#   export LOGFILE_OLD=relative/or/absolute/path/to/logfile.log.old  # Optional
-#   export LOG_MAX_SIZE=16384  # Optional, bytes
-#   source "$(dirname $0)/logger.zsh"
-#   log_info "Message"
-#   log_error "Error message"
-#   log_debug "Debug message"
-#   log_json "INFO" "Message"  # JSON log format
+# Simple, reliable logger for GoProX
+# All output goes to stderr to avoid interfering with interactive prompts
 #
-# If LOGFILE and LOGFILE_OLD are not set, defaults are output/goprox.log and output/goprox.log.old
 
-# --- Configurable Variables ---
-: "${LOGFILE:=output/goprox.log}"
-: "${LOGFILE_OLD:=output/goprox.log.old}"
-: "${LOG_MAX_SIZE:=1048576}"
-mkdir -p "$(dirname "$LOGFILE")"
-: > "$LOGFILE"
+# Simple logging functions - no fallbacks, no complexity
+log_info() {
+    echo "[INFO] $*" >&2
+}
 
-# --- Internal Helpers ---
-function _log_rotate_if_needed() {
-  if [[ -f "$LOGFILE" ]]; then
-    local file_size=0
-    # Try to get file size with fallback to 0
-    if command -v stat >/dev/null 2>&1; then
-      file_size=$(stat -f %z "$LOGFILE" 2>/dev/null || stat -c %s "$LOGFILE" 2>/dev/null || echo "0")
+log_success() {
+    echo "[SUCCESS] $*" >&2
+}
+
+log_warning() {
+    echo "[WARNING] $*" >&2
+}
+
+log_error() {
+    echo "[ERROR] $*" >&2
+}
+
+log_debug() {
+    if [[ "${DEBUG:-}" == "1" || "${DEBUG:-}" == "true" ]]; then
+        echo "[DEBUG] $*" >&2
     fi
-    # Ensure file_size is numeric
-    if [[ "$file_size" =~ ^[0-9]+$ ]] && [[ "$file_size" -ge $LOG_MAX_SIZE ]]; then
-      mv "$LOGFILE" "$LOGFILE_OLD"
-      : > "$LOGFILE"
-    fi
-  fi
 }
-
-function _log_write() {
-  local level="$1"
-  local msg="$2"
-  local ts
-  ts="$(date '+%Y-%m-%d %H:%M:%S')"
-  local branch_display=$(get_branch_display)
-  _log_rotate_if_needed
-  echo "[$ts] [$branch_display] [$level] $msg" | tee -a "$LOGFILE" >&2
-}
-
-function log_info()    { _log_write "INFO"    "$*"; }
-function log_success() { _log_write "SUCCESS" "$*"; }
-function log_warning() { _log_write "WARNING" "$*"; }
-function log_error()   { _log_write "ERROR"   "$*"; }
-function log_debug()   { [[ "$LOG_VERBOSE" == 1 ]] && _log_write "DEBUG" "$*"; }
-function log_warn()    { _log_write "WARN"    "$*"; }
-function log_json()    {
-  local level="$1"; shift
-  local msg="$*"
-  local ts
-  ts="$(date '+%Y-%m-%dT%H:%M:%S')"
-  local branch_display=$(get_branch_display)
-  _log_rotate_if_needed
-  echo "{\"timestamp\":\"$ts\",\"level\":\"$level\",\"message\":\"$msg\",\"branch\":\"$branch_display\"}" | tee -a "$LOGFILE"
-}
-
-function log_time_start() {
-  export LOG_TIME_START=$(date +%s)
-}
-function log_time_end() {
-  local end=$(date +%s)
-  local duration=$((end - LOG_TIME_START))
-  log_info "Elapsed time: ${duration}s"
-}
-
-# Set up error trap for debugging (only in interactive mode or when explicitly enabled)
-# More robust error trap that only triggers on actual script errors
-if [[ "${INTERACTIVE:-}" == "true" || "${ENABLE_ERROR_TRAP:-}" == "true" ]]; then
-    # Only trap errors from the main script, not from expected command failures
-    # Use a more specific condition to avoid false positives
-    trap 'if [[ $? -ne 0 && $BASH_SUBSHELL -eq 0 && -n "${SCRIPT_NAME:-}" ]]; then log_error "Error on line $LINENO (exit code: $?)"; fi' ERR
-fi
-
-# --- Usage Example ---
-# source scripts/core/logger.zsh
-# log_info "Starting script"
-# log_debug "Debug info"
-# log_json "INFO" "Structured log message"
-# log_time_start
-# ... your code ...
-# log_time_end
-# log_trap_errors 
 
 # Function to prominently display current branch information
 display_branch_info() {
@@ -116,84 +54,3 @@ display_branch_info() {
     echo "===================="
     echo ""
 }
-
-# Function to display branch info before critical operations
-display_branch_warning() {
-    local operation="$1"
-    local target_branch="$2"
-    local current_branch=$(git branch --show-current 2>/dev/null || echo "unknown")
-    
-    if [[ "$current_branch" != "$target_branch" ]]; then
-        echo ""
-        echo "⚠️  BRANCH MISMATCH WARNING"
-        echo "=========================="
-        echo "📍 CURRENT BRANCH: $current_branch"
-        echo "📍 EXPECTED BRANCH: $target_branch"
-        echo "📍 OPERATION: $operation"
-        echo "=========================="
-        echo ""
-        echo "❓ Do you want to continue anyway? (y/N)"
-        read -r response
-        if [[ ! "$response" =~ ^[Yy]$ ]]; then
-            log_error "Operation cancelled due to branch mismatch"
-            exit 1
-        fi
-    fi
-}
-
-# Function to generate short branch hash (Git-style)
-get_branch_hash() {
-    local branch="$1"
-    echo "$branch" | sha1sum | cut -c1-8
-}
-
-# Function to get current branch with hash display
-get_branch_display() {
-    local current_branch=$(git branch --show-current 2>/dev/null || echo "unknown")
-    local branch_hash=$(get_branch_hash "$current_branch")
-    
-    # For short branches (≤15 chars), show full name
-    # For longer branches, show type prefix + hash
-    if [[ ${#current_branch} -le 15 ]]; then
-        echo "$current_branch"
-    else
-        # Extract branch type prefix
-        local branch_type=""
-        if [[ "$current_branch" =~ ^fix/ ]]; then
-            branch_type="fix"
-        elif [[ "$current_branch" =~ ^feat/ ]]; then
-            branch_type="feat"
-        elif [[ "$current_branch" =~ ^feature/ ]]; then
-            branch_type="feat"
-        elif [[ "$current_branch" =~ ^release/ ]]; then
-            branch_type="rel"
-        elif [[ "$current_branch" =~ ^hotfix/ ]]; then
-            branch_type="hot"
-        elif [[ "$current_branch" == "develop" ]]; then
-            branch_type="dev"
-        elif [[ "$current_branch" == "main" ]]; then
-            branch_type="main"
-        else
-            branch_type="br"
-        fi
-        
-        echo "${branch_type}/${branch_hash}"
-    fi
-}
-
-# Function to get full branch name from hash (for debugging)
-get_full_branch_name() {
-    local hash="$1"
-    local current_branch=$(git branch --show-current 2>/dev/null || echo "unknown")
-    local current_hash=$(get_branch_hash "$current_branch")
-    
-    if [[ "$current_hash" == "$hash" ]]; then
-        echo "$current_branch"
-    else
-        echo "unknown"
-    fi
-}
-
-# Enhanced logging functions with branch awareness
-# NOTE: These functions are now consolidated with the original ones above
-# to avoid duplicate definitions and ensure rotation works properly 

--- a/scripts/release/release.zsh
+++ b/scripts/release/release.zsh
@@ -1,5 +1,4 @@
 #!/bin/zsh
-echo "Release script starting..." >&2
 #
 # release.zsh: Simplified top-level release script for GoProX
 #
@@ -16,6 +15,9 @@ set -euo pipefail
 
 # Source project logger
 source "$SCRIPT_DIR/../core/logger.zsh"
+
+# Log script start
+log_info "Release script starting..."
 
 # Configuration
 GITFLOW_SCRIPT="$SCRIPT_DIR/gitflow-release.zsh"

--- a/scripts/release/release.zsh
+++ b/scripts/release/release.zsh
@@ -144,62 +144,35 @@ suggest_next_version() {
     esac
 }
 
-# Function to safely call logger functions
-safe_log() {
-    local level="$1"
-    local message="$2"
-    
-    case "$level" in
-        info)
-            log_info "$message" || echo "INFO: $message" >&2
-            ;;
-        success)
-            log_success "$message" || echo "SUCCESS: $message" >&2
-            ;;
-        warning)
-            log_warning "$message" || echo "WARNING: $message" >&2
-            ;;
-        error)
-            log_error "$message" || echo "ERROR: $message" >&2
-            ;;
-        debug)
-            log_debug "$message" || echo "DEBUG: $message" >&2
-            ;;
-        *)
-            echo "UNKNOWN: $message" >&2
-            ;;
-    esac
-}
-
 # Function to check prerequisites
 check_prerequisites() {
-    safe_log info "Checking prerequisites..."
+    log_info "Checking prerequisites..."
     
     # Check if we're in a git repository
     if ! git rev-parse --git-dir > /dev/null 2>&1; then
-        safe_log error "Not in a git repository"
+        log_error "Not in a git repository"
         exit 1
     fi
     
     # Check if gh CLI is available
     if ! command -v gh &> /dev/null; then
-        safe_log error "GitHub CLI (gh) is not installed. Please install it first: https://cli.github.com/"
+        log_error "GitHub CLI (gh) is not installed. Please install it first: https://cli.github.com/"
         exit 1
     fi
     
     if ! gh auth status &> /dev/null; then
-        safe_log error "Not authenticated with GitHub CLI. Please run: gh auth login"
+        log_error "Not authenticated with GitHub CLI. Please run: gh auth login"
         exit 1
     fi
     
     # Check if required scripts exist
     if [[ ! -f "$GITFLOW_SCRIPT" ]]; then
-        safe_log error "gitflow-release.zsh script not found: $GITFLOW_SCRIPT"
+        log_error "gitflow-release.zsh script not found: $GITFLOW_SCRIPT"
         exit 1
     fi
     
-    safe_log success "All prerequisites met"
-    safe_log debug "Prerequisites check completed, proceeding to main logic"
+    log_success "All prerequisites met"
+    log_debug "Prerequisites check completed, proceeding to main logic"
 }
 
 # Function to display current status
@@ -223,17 +196,17 @@ display_status() {
 interactive_mode() {
     local release_type="$1"
     
-    echo "Interactive mode called with release_type: '$release_type'" >&2
-    safe_log debug "Starting interactive mode with release_type: '$release_type'"
+    log_debug "Interactive mode called with release_type: '$release_type'"
+    log_debug "Starting interactive mode with release_type: '$release_type'"
     
-    echo "About to call display_status..." >&2
+    log_debug "About to call display_status..."
     display_status
-    echo "display_status completed" >&2
+    log_debug "display_status completed"
     
     # Determine release type if not specified
     if [[ -z "$release_type" ]]; then
-        echo "No release type specified, prompting user..." >&2
-        safe_log debug "No release type specified, prompting user"
+        log_debug "No release type specified, prompting user..."
+        log_debug "No release type specified, prompting user"
         echo "Select release type:"
         echo "1) Official Release (production)"
         echo "2) Beta Release (testing)"
@@ -241,21 +214,21 @@ interactive_mode() {
         echo "4) Dry Run (test without release)"
         echo ""
         local choice
-        echo "About to call safe_prompt for release type choice..." >&2
-        safe_log debug "About to call safe_prompt for release type choice"
+        log_debug "About to call safe_prompt for release type choice..."
+        log_debug "About to call safe_prompt for release type choice"
         choice=$(safe_prompt "Enter choice (1-4)" "1")
-        echo "safe_prompt returned: '$choice'" >&2
-        safe_log debug "safe_prompt returned: '$choice'"
+        log_debug "safe_prompt returned: '$choice'"
+        log_debug "safe_prompt returned: '$choice'"
         
         case "$choice" in
             1) release_type="official" ;;
             2) release_type="beta" ;;
             3) release_type="dev" ;;
             4) release_type="dry-run" ;;
-            *) safe_log error "Invalid choice: '$choice'"; exit 1 ;;
+            *) log_error "Invalid choice: '$choice'"; exit 1 ;;
         esac
-        echo "Selected release type: '$release_type'" >&2
-        safe_log debug "Selected release type: '$release_type'"
+        log_debug "Selected release type: '$release_type'"
+        log_debug "Selected release type: '$release_type'"
     fi
     
     # Get previous version
@@ -271,9 +244,9 @@ interactive_mode() {
     fi
     
     echo ""
-    safe_log debug "About to call safe_prompt for previous version"
+    log_debug "About to call safe_prompt for previous version"
     prev_version=$(safe_prompt "Previous version for changelog" "$suggested_prev")
-    safe_log debug "safe_prompt returned prev_version: '$prev_version'"
+    log_debug "safe_prompt returned prev_version: '$prev_version'"
     
     # Validate previous version
     if ! validate_version "$prev_version"; then
@@ -288,26 +261,26 @@ interactive_mode() {
     echo "3) Patch (X.X.X)"
     echo ""
     local bump_choice
-    safe_log debug "About to call safe_prompt for bump choice"
+    log_debug "About to call safe_prompt for bump choice"
     bump_choice=$(safe_prompt "Enter choice (1-3)" "2")
-    safe_log debug "safe_prompt returned bump_choice: '$bump_choice'"
+    log_debug "safe_prompt returned bump_choice: '$bump_choice'"
     
     local bump_type="minor"
     case "$bump_choice" in
         1) bump_type="major" ;;
         2|"") bump_type="minor" ;;
         3) bump_type="patch" ;;
-        *) safe_log error "Invalid choice: '$bump_choice'"; exit 1 ;;
+        *) log_error "Invalid choice: '$bump_choice'"; exit 1 ;;
     esac
-    safe_log debug "Selected bump type: '$bump_type'"
+    log_debug "Selected bump type: '$bump_type'"
     
     # Suggest next version
     local suggested_version=$(suggest_next_version "$current_version" "$bump_type")
     
     echo ""
-    safe_log debug "About to call safe_prompt for next version"
+    log_debug "About to call safe_prompt for next version"
     next_version=$(safe_prompt "Next version" "$suggested_version")
-    safe_log debug "safe_prompt returned next_version: '$next_version'"
+    log_debug "safe_prompt returned next_version: '$next_version'"
     
     # Validate next version
     if ! validate_version "$next_version"; then
@@ -317,9 +290,9 @@ interactive_mode() {
     # Ask about monitoring
     echo ""
     local monitor_choice
-    safe_log debug "About to call safe_prompt for monitor choice"
+    log_debug "About to call safe_prompt for monitor choice"
     monitor_choice=$(safe_prompt "Monitor workflow completion? (y/N)" "N")
-    safe_log debug "safe_prompt returned monitor_choice: '$monitor_choice'"
+    log_debug "safe_prompt returned monitor_choice: '$monitor_choice'"
     local monitor_flag=""
     if [[ "${monitor_choice}" == "y" || "${monitor_choice}" == "Y" ]]; then
         monitor_flag="--monitor"
@@ -335,12 +308,12 @@ interactive_mode() {
     echo "  Monitor: ${monitor_choice:-N}"
     echo ""
     
-    safe_log debug "About to call safe_confirm for final confirmation"
+    log_debug "About to call safe_confirm for final confirmation"
     if ! safe_confirm "Proceed with release? (y/N)"; then
-        safe_log info "Release cancelled"
+        log_info "Release cancelled"
         exit 0
     fi
-    safe_log debug "User confirmed release"
+    log_debug "User confirmed release"
     
     # Execute release
     execute_release "$release_type" "$prev_version" "$next_version" "$bump_type" "$monitor_flag"
@@ -356,7 +329,7 @@ batch_mode() {
     
     # Validate required parameters
     if [[ -z "$release_type" || -z "$prev_version" ]]; then
-        safe_log error "Batch mode requires release_type and prev_version"
+        log_error "Batch mode requires release_type and prev_version"
         show_usage
         exit 1
     fi
@@ -382,10 +355,10 @@ execute_release() {
     local bump_type="$4"
     local monitor_flag="$5"
     
-    safe_log info "Executing $release_type release..."
-    safe_log info "Previous version: $prev_version"
-    safe_log info "Next version: $next_version"
-    safe_log info "Bump type: $bump_type"
+    log_info "Executing $release_type release..."
+    log_info "Previous version: $prev_version"
+    log_info "Next version: $next_version"
+    log_info "Bump type: $bump_type"
     
     # Build command based on release type
     local cmd=""
@@ -426,26 +399,26 @@ execute_release() {
             ;;
     esac
     
-    safe_log info "Executing: $cmd"
+    log_info "Executing: $cmd"
     echo ""
     
     # Execute the command
     eval "$cmd"
     
     if [[ $? -eq 0 ]]; then
-        safe_log success "$release_type release completed successfully"
+        log_success "$release_type release completed successfully"
     else
-        safe_log error "$release_type release failed"
+        log_error "$release_type release failed"
         exit 1
     fi
 }
 
 # Main script logic
 main() {
-    echo "Main function called with arguments: $@" >&2
+    log_debug "Main function called with arguments: $@"
     
     # Initialize variables
-    echo "Initializing variables..." >&2
+    log_debug "Initializing variables..."
     local PREV_VERSION=""
     local VERSION=""
     local VERSION_TYPE="minor"
@@ -461,10 +434,10 @@ main() {
     local VERBOSE=false
     local QUIET=false
     
-    echo "Variables initialized, starting option parsing" >&2
+    log_debug "Variables initialized, starting option parsing"
     
     # Parse options using zparseopts for strict parameter validation
-    echo "About to call zparseopts with arguments: $@" >&2
+    log_debug "About to call zparseopts with arguments: $@"
     declare -A opts
     zparseopts -D -E -F -A opts - \
                 h -help \
@@ -486,14 +459,14 @@ main() {
                 --config: \
                 || {
         # Unknown option
-        echo "zparseopts failed" >&2
+        log_debug "zparseopts failed"
         log_error "Unknown option: $@"
         exit 1
     }
-    echo "zparseopts completed successfully" >&2
+    log_debug "zparseopts completed successfully"
     
     # Process parsed options
-    echo "Processing parsed options..." >&2
+    log_debug "Processing parsed options..."
     for key val in "${(kv@)opts}"; do
         case $key in
             -h|--help)
@@ -550,10 +523,10 @@ main() {
                 ;;
         esac
     done
-    echo "Options processed" >&2
+    log_debug "Options processed"
     
     # Parse command line arguments
-    echo "Parsing command line arguments..." >&2
+    log_debug "Parsing command line arguments..."
     local release_type=""
     local prev_version="$PREV_VERSION"
     local next_version="$VERSION"
@@ -604,29 +577,29 @@ main() {
                 ;;
         esac
     done
-    echo "Command line arguments parsed" >&2
+    log_debug "Command line arguments parsed"
     
     # Check prerequisites
-    echo "About to call check_prerequisites..." >&2
-    echo "Checking prerequisites..." >&2
+    log_debug "About to call check_prerequisites..."
+    log_debug "Checking prerequisites..."
     check_prerequisites
-    echo "Prerequisites checked" >&2
-    echo "About to execute based on mode..." >&2
+    log_debug "Prerequisites checked"
+    log_debug "About to execute based on mode..."
     
     # Execute based on mode
-    echo "Executing based on mode..." >&2
+    log_debug "Executing based on mode..."
     if [[ "${BATCH_MODE:-false}" == "true" ]]; then
-        echo "Running batch mode" >&2
+        log_debug "Running batch mode"
         batch_mode "$release_type" "$prev_version" "$next_version" "$bump_type" "$monitor_flag"
     else
-        echo "Running interactive mode" >&2
+        log_debug "Running interactive mode"
         interactive_mode "$release_type"
     fi
 }
 
 # Run main function
-echo "About to call main function" >&2
-echo "Arguments: $@" >&2
-echo "Function exists: $(type main 2>/dev/null || echo 'NO')" >&2
+log_debug "About to call main function"
+log_debug "Arguments: $@"
+log_debug "Function exists: $(type main 2>/dev/null || echo 'NO')"
 main "$@"
-echo "Main function call completed" >&2 
+log_debug "Main function call completed" 


### PR DESCRIPTION
- Replace overengineered logger with simple, robust version
- Restore timestamp and branch formatting to logger output
- Make debug output conditional on DEBUG=1 or DEBUG=true
- Replace all echo DEBUG statements with log_debug calls
- Remove all debug mode wrappers - logger handles debug control
- Fix safe-prompt to output prompts to stderr (prevents command substitution issues)
- Ensure interactive release script works without debug interference
- Confirm all remaining echo statements are for UI or prompt output only
- Follow Unix best practices for prompt output

Closes #67, #71, #72